### PR TITLE
[inno] add cancel option and fix semicolon bug in win env vars

### DIFF
--- a/inno/build setup.iss
+++ b/inno/build setup.iss
@@ -1,7 +1,7 @@
 #include "environment.iss"
 
 #define MyAppName "Cover Art"
-#define MyAppVersion "1.2"
+#define MyAppVersion "1.1"
 #define MyAppPublisher "Tetrax-10"
 #define MyURL "https://github.com/Tetrax-10"
 #define MyAppURL "https://github.com/Tetrax-10/jellyfin-cover-art"

--- a/inno/build setup.iss
+++ b/inno/build setup.iss
@@ -1,7 +1,7 @@
 #include "environment.iss"
 
 #define MyAppName "Cover Art"
-#define MyAppVersion "1.1"
+#define MyAppVersion "1.2"
 #define MyAppPublisher "Tetrax-10"
 #define MyURL "https://github.com/Tetrax-10"
 #define MyAppURL "https://github.com/Tetrax-10/jellyfin-cover-art"
@@ -23,6 +23,7 @@ Compression=lzma
 SolidCompression=yes
 WizardStyle=modern
 ChangesEnvironment=true
+AllowCancelDuringInstall=true
 
 [Languages]
 Name: "english"; MessagesFile: "compiler:Default.isl"

--- a/inno/environment.iss
+++ b/inno/environment.iss
@@ -1,44 +1,126 @@
-[Code]
-const EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
+const
+  EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
+  WM_SETTINGCHANGE = $001A;
+  SMTO_ABORTIFHUNG = $0002;
+  
+type
+  WPARAM = LongWord;
+  LPARAM = LongInt;
+  LRESULT = LongInt;
+  PChar = String;
+  
+function SendMessageTimeout(hWnd: HWND; Msg: UINT; wParam: WPARAM; lParam: PChar;
+  fuFlags, uTimeout: UINT; out lpdwResult: DWORD): LRESULT;
+  external 'SendMessageTimeoutW@user32.dll stdcall';
+
+function PosEx(const SubStr, S: String; Offset: Integer): Integer;
+var
+  i: Integer;
+begin
+  for i := Offset to Length(S) - Length(SubStr) + 1 do
+  begin
+    if Copy(S, i, Length(SubStr)) = SubStr then
+    begin
+      Result := i;
+      Exit;
+    end;
+  end;
+  Result := 0;
+end;  
+  
+function SplitString(const S: String; const Delimiter: String): TArrayOfString;
+var
+  PosStart, PosDel, Index: Integer;
+begin
+  SetArrayLength(Result, 0);
+  PosStart := 1;
+  Index := 0;
+
+  repeat
+    PosDel := PosEx(Delimiter, S, PosStart);
+    if PosDel = 0 then
+      PosDel := Length(S) + 1;
+
+    SetArrayLength(Result, Index + 1);
+    Result[Index] := Copy(S, PosStart, PosDel - PosStart);
+    PosStart := PosDel + Length(Delimiter);
+    Index := Index + 1;
+  until PosStart > Length(S);
+end;
+   
+procedure NotifyEnvironmentChange;
+var
+  ResultCode: DWORD;
+begin
+  SendMessageTimeout(HWND_BROADCAST, WM_SETTINGCHANGE, 0,
+    PChar(ExpandConstant('Environment')), SMTO_ABORTIFHUNG, 5000, ResultCode);
+end;
 
 procedure EnvAddPath(Path: string);
 var
-    Paths: string;
+  Paths: string;
+  PathList: TArrayOfString;
+  I: Integer;
+  Found: Boolean;
 begin
-    { Retrieve current path (use empty string if entry not exists) }
-    if not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths)
-    then Paths := '';
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths) then
+    Paths := '';
 
-    { Skip if string already found in path }
-    if Pos(';' + Uppercase(Path) + ';', ';' + Uppercase(Paths) + ';') > 0 then exit;
+  PathList := SplitString(Paths, ';');
+  Found := False;
 
-    { App string to the end of the path variable }
-    Paths := Paths + ';'+ Path +';'
+  for I := 0 to GetArrayLength(PathList) - 1 do
+  begin
+    if CompareText(Trim(PathList[I]), Trim(Path)) = 0 then
+    begin
+      Found := True;
+      break;
+    end;
+  end;
 
-    { Overwrite (or create if missing) path environment variable }
-    if RegWriteStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths)
-    then Log(Format('The [%s] added to PATH: [%s]', [Path, Paths]))
-    else Log(Format('Error while adding the [%s] to PATH: [%s]', [Path, Paths]));
+  if not Found then
+  begin
+    if (Length(Paths) > 0) and (Paths[Length(Paths)] <> ';') then
+      Paths := Paths + ';';
+    Paths := Paths + Path;
+
+    if RegWriteStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths) then
+    begin
+      Log(Format('Added "%s" to PATH. New PATH: "%s"', [Path, Paths]));
+      NotifyEnvironmentChange;
+    end
+    else
+      Log(Format('Error adding "%s" to PATH. Original PATH: "%s"', [Path, Paths]));
+  end;
 end;
 
 procedure EnvRemovePath(Path: string);
 var
-    Paths: string;
-    P: Integer;
+  Paths, CleanPaths: string;
+  PathList: TArrayOfString;
+  I: Integer;
 begin
-    { Skip if registry entry not exists }
-    if not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths) then
-        exit;
+  if not RegQueryStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths) then
+    exit;
 
-    { Skip if string not found in path }
-    P := Pos(';' + Uppercase(Path) + ';', ';' + Uppercase(Paths) + ';');
-    if P = 0 then exit;
+  PathList := SplitString(Paths, ';');
+  CleanPaths := '';
 
-    { Update path variable }
-    Delete(Paths, P - 1, Length(Path) + 1);
+  for I := 0 to GetArrayLength(PathList) - 1 do
+  begin
+    if CompareText(Trim(PathList[I]), Trim(Path)) <> 0 then
+    begin
+      if CleanPaths <> '' then
+        CleanPaths := CleanPaths + ';';
+      CleanPaths := CleanPaths + PathList[I];
+    end;
+  end;
 
-    { Overwrite path environment variable }
-    if RegWriteStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', Paths)
-    then Log(Format('The [%s] removed from PATH: [%s]', [Path, Paths]))
-    else Log(Format('Error while removing the [%s] from PATH: [%s]', [Path, Paths]));
+  if RegWriteStringValue(HKEY_LOCAL_MACHINE, EnvironmentKey, 'Path', CleanPaths) then
+  begin
+    Log(Format('Removed "%s" from PATH. New PATH: "%s"', [Path, CleanPaths]));
+    NotifyEnvironmentChange;
+  end
+  else
+    Log(Format('Error removing "%s" from PATH. Original PATH: "%s"', [Path, Paths]));
 end;

--- a/inno/environment.iss
+++ b/inno/environment.iss
@@ -1,3 +1,4 @@
+[Code]
 const
   EnvironmentKey = 'SYSTEM\CurrentControlSet\Control\Session Manager\Environment';
   WM_SETTINGCHANGE = $001A;


### PR DESCRIPTION
Fixed semicolon bug during create/delete env variable, also added wind notification so restart is not needed when installed or deleted.